### PR TITLE
Object Recursion + Force JSON Format

### DIFF
--- a/SteamCommunity.php
+++ b/SteamCommunity.php
@@ -30,6 +30,7 @@ class SteamCommunity
 
     private $steamId;
     private $sessionId;
+    private $steamCookies = 'cookies';
 
     private $requiresCaptcha = false;
     private $captchaGID;
@@ -75,7 +76,6 @@ class SteamCommunity
 
         if (!$mobile) {
             $this->market = new Market($this);
-            $this->tradeOffers = new TradeOffers($this);
         }
     }
 
@@ -97,6 +97,9 @@ class SteamCommunity
                 $this->mobileAuth->setOauth(file_get_contents($this->getAuthFilePath()));
             }
             $this->loggedIn = true;
+            if (is_null($this->tradeOffers)){
+                $this->tradeOffers = new TradeOffers($this->sessionId, $this->apiKey);
+            }
             return LoginResult::LoginOkay;
         }
 
@@ -159,6 +162,7 @@ class SteamCommunity
                 file_put_contents($this->getAuthFilePath(), $loginJson['oauth']);
             }
             $this->_setSession();
+            $this->tradeOffers = new TradeOffers($this->sessionId, $this->apiKey);
             $this->loggedIn = true;
             return LoginResult::LoginOkay;
         }
@@ -224,8 +228,8 @@ class SteamCommunity
         curl_setopt ($ch, CURLOPT_SSL_VERIFYPEER, 0);
         curl_setopt ($ch, CURLOPT_SSL_VERIFYHOST, 0);
         if (!empty($this->rootDir)) {
-            curl_setopt($ch, CURLOPT_COOKIEFILE, $this->_getCookieFilePath());
-            curl_setopt($ch, CURLOPT_COOKIEJAR, $this->_getCookieFilePath());
+            curl_setopt($ch, CURLOPT_COOKIEFILE, $this->steamCookies);
+            curl_setopt($ch, CURLOPT_COOKIEJAR, $this->steamCookies);
         }
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);

--- a/TradeOffers/Trade.php
+++ b/TradeOffers/Trade.php
@@ -10,37 +10,38 @@ namespace waylaidwanderer\SteamCommunity\TradeOffers;
 
 
 use waylaidwanderer\SteamCommunity\Helper;
-use waylaidwanderer\SteamCommunity\SteamCommunity;
 use waylaidwanderer\SteamCommunity\TradeOffers\Trade\TradeAsset;
 use waylaidwanderer\SteamCommunity\TradeOffers\Trade\TradeUser;
 
-class Trade implements \JsonSerializable
+class Trade
 {
     private $newVersion = true;
     private $version = 1;
     private $me;
     private $them;
-    private $steamCommunity;
+    private $steamCookies;
+    private $sessionId;
     private $accountId;
 
     private $message = '';
 
-    public function __construct(SteamCommunity $steamCommunity, $accountId)
+    public function __construct($sessionId, $accountId)
     {
         $this->me = new TradeUser($this);
         $this->them = new TradeUser($this);
-        $this->steamCommunity = $steamCommunity;
+        $this->sessionId = $sessionId;
         $this->accountId = $accountId;
+        $this->steamCookies = dirname(__FILE__) . '/../cookies';
     }
 
-    public function jsonSerialize()
+    public function getEncoded()
     {
-        return [
-            'newversion' => $this->newVersion,
-            'version' => $this->version,
-            'me' => $this->me,
-            'them' => $this->them
-        ];
+        if ($this->newVersion){
+            $newVersionString = "true";
+        } else {
+            $newVersionString = "false";
+        }
+        return urlencode('{"newversion":' . $newVersionString . ',"version":' . $this->version . ',"me":{' . $this->me->getEncoded() . '}"them":{' . $this->them->getEncoded() . '}}');
     }
 
     public function addMyItem($appId, $contextId, $assetId, $amount = 1)
@@ -74,17 +75,20 @@ class Trade implements \JsonSerializable
     {
         $url = 'https://steamcommunity.com/tradeoffer/new/send';
         $referer = 'https://steamcommunity.com/tradeoffer/new/?partner=' . $this->accountId;
+        
+        if ($token != ''){
+            $referer .= "&token=" . $token;
+        }
+        
         $params = [
-            'sessionid' => $this->steamCommunity->getSessionId(),
+            'sessionid' => $this->sessionId,
             'serverid' => '1',
             'partner' => Helper::toCommunityID($this->accountId),
             'tradeoffermessage' => $this->message,
             'json_tradeoffer' => json_encode($this),
-            'trade_offer_create_params' => (empty($token) ? "{}" : json_encode([
-                'trade_offer_access_token' => $token
-            ]))
+            'trade_offer_create_params' => (empty($token) ? "{}" : urlencode('{"trade_offer_access_token":"' . $token . '"}'))
         ];
-        $response = $this->steamCommunity->cURL($url, $referer, $params);
+        $response = $this->cURL($url, $referer, $params);
         $json = json_decode($response, true);
         if (is_null($json)) {
             return 0;
@@ -96,6 +100,43 @@ class Trade implements \JsonSerializable
             }
         }
     }
+
+    public function cURL($url, $ref = NULL, $postData = NULL)
+    {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_COOKIEJAR, $this->steamCookies);
+        curl_setopt($ch, CURLOPT_COOKIEFILE, $this->steamCookies);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_HEADER, true);
+        curl_setopt ($ch, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_setopt ($ch, CURLOPT_SSL_VERIFYHOST, 0);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 0);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_FAILONERROR, true);
+        curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:27.0) Gecko/20100101 Firefox/27.0');
+        
+        if (isset($ref)) {
+            curl_setopt($ch, CURLOPT_REFERER, $ref);
+        }
+        
+        if (isset($postData)) {
+            curl_setopt($ch, CURLOPT_POST, true);
+            $postStr = "";
+            
+            foreach ($postData as $key => $value) {
+                if ($postStr)
+                    $postStr .= "&";
+                $postStr .= $key . "=" . $value;
+            }
+            
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $postStr);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array("Content-type:application/x-www-form-urlencoded; charset=UTF-8","Content-length:" . strlen($postStr)));
+        }
+        
+        $output = curl_exec($ch);
+        curl_close($ch);
+        return $output;
 
     /**
      * @return int

--- a/TradeOffers/Trade/TradeAsset.php
+++ b/TradeOffers/Trade/TradeAsset.php
@@ -9,7 +9,7 @@
 namespace waylaidwanderer\SteamCommunity\TradeOffers\Trade;
 
 
-class TradeAsset implements \JsonSerializable
+class TradeAsset
 {
     private $appId;
     private $contextId;
@@ -24,14 +24,9 @@ class TradeAsset implements \JsonSerializable
         $this->amount = $amount;
     }
 
-    public function jsonSerialize()
+    public function getEncoded()
     {
-        return [
-            'appid' => (int)$this->appId,
-            'contextid' => $this->contextId,
-            'assetid' => $this->assetId,
-            'amount' => (int)$this->amount
-        ];
+        return '{"appid":' . $this->appId . ',"contextid":"' . $this->contextId . '","amount":' . $this->amount . ',"assetid":"' . $this->assetId . '"},';
     }
 
     /**

--- a/TradeOffers/Trade/TradeUser.php
+++ b/TradeOffers/Trade/TradeUser.php
@@ -10,17 +10,16 @@ use waylaidwanderer\SteamCommunity\TradeOffers\Trade;
  * Date: 2015-12-28
  * Time: 2:29 PM
  */
-class TradeUser implements \JsonSerializable
+class TradeUser
 {
     /** @var TradeAsset[] $assets */
     private $assets = [];
+    private $assetsString = '';
     private $currency = [];
     private $ready = false;
-    private $trade;
 
-    public function __construct(Trade $trade)
+    public function __construct()
     {
-        $this->trade = $trade;
     }
 
     public function addItem(TradeAsset $asset)
@@ -37,18 +36,19 @@ class TradeUser implements \JsonSerializable
         if ($exists) {
             return false;
         } else {
-            $this->trade->setVersion($this->trade->getVersion() + 1);
+            $this->assetsString .= $asset->getEncoded();
             $this->assets[] = $asset;
             return true;
         }
     }
 
-    public function jsonSerialize()
+    public function getEncoded()
     {
-        return [
-            'assets' => $this->assets,
-            'currency' => $this->currency,
-            'ready' => $this->ready
-        ];
+        if ($this->ready){
+            $ready = "true";
+        } else {
+            $ready = "false";
+        }
+        return '"assets":[' . substr($this->assetsString, 0, -1) . '],"currency":[],"ready":' . $ready;
     }
 }


### PR DESCRIPTION
Well, all I can say is that I **_REALLY**_ hope I added all the lines properly. I was moving my code from my own project (very different setup from yours) into my fork, so point out any inconsistency with naming. All those cURL functions are intentional, btw.

I noticed once, that as I was echoing out some trade objects, it was recursing to infinity. It promptly printed the object, with `*RECURSION*` as the property for the included objects of objects.

Basically what was happening was that the TradeOffers class was getting the SteamCommunity class, and this basically caused SteamCommunity to include TradeOffers which included SteamCommunity including TradeOffers again. As you can see, this causes stack overflows (which PHP completely  ignores, not even raising a NOTICE error upon running.) I just fixed this because recursing infinitely isn't something that should happen in code, especially with objects.

I also adjusted the json encode functions to call a custom `getEncoded()` function which returns a string formatted as a json string. And once you urlencode those strings, you end up getting a post string identical to the way steam does it.
