### PR TITLE
Parse and save offer id in confirmation object on fetch confirmation page

### DIFF
--- a/MobileAuth/Confirmations.php
+++ b/MobileAuth/Confirmations.php
@@ -38,17 +38,20 @@ class Confirmations
         if (strpos($response, '<div>Nothing to confirm</div>') === false) {
             $confIdRegex = '/data-confid="(\d+)"/';
             $confKeyRegex = '/data-key="(\d+)"/';
+            $confOfferRegex = '/data-creator="(\d+)"/';
             $confDescRegex = '/<div>((Confirm|Trade with|Sell -) .+)<\/div>/';
 
             preg_match_all($confIdRegex, $response, $confIdMatches);
             preg_match_all($confKeyRegex, $response, $confKeyMatches);
+            preg_match_all($confOfferRegex, $response, $confOfferMatches);
             preg_match_all($confDescRegex, $response, $confDescMatches);
-            if (count($confIdMatches[1]) > 0 && count($confKeyMatches[1]) > 0 && count($confDescMatches) > 0) {
+            if (count($confIdMatches[1]) > 0 && count($confKeyMatches[1]) > 0 && count($confDescMatches) > 0 && count($confOfferMatches) > 0) {
                 for ($i = 0; $i < count($confIdMatches[1]); $i++) {
                     $confId = $confIdMatches[1][$i];
                     $confKey = $confKeyMatches[1][$i];
+                    $confOfferId = $confOfferMatches[1][$i];
                     $confDesc = $confDescMatches[1][$i];
-                    $confirmations[] = new Confirmation($confId, $confKey, $confDesc);
+                    $confirmations[] = new Confirmation($confId, $confKey, $confOfferId, $confDesc);
                 }
             } else {
                 throw new WgTokenInvalidException();

--- a/MobileAuth/Confirmations/Confirmation.php
+++ b/MobileAuth/Confirmations/Confirmation.php
@@ -13,12 +13,14 @@ class Confirmation
 {
     private $confirmationId;
     private $confirmationKey;
+    private $confirmationOfferId;
     private $confirmationDescription;
 
-    public function __construct($confirmationId, $confirmationKey, $confirmationDescription)
+    public function __construct($confirmationId, $confirmationKey, $confirmationOfferId, $confirmationDescription)
     {
         $this->confirmationId = $confirmationId;
         $this->confirmationKey = $confirmationKey;
+        $this->confirmationOfferId = $confirmationOfferId;
         $this->confirmationDescription = $confirmationDescription;
     }
 
@@ -44,5 +46,13 @@ class Confirmation
     public function getConfirmationDescription()
     {
         return $this->confirmationDescription;
+    }
+
+    /**
+     * @return string
+     */
+    public function getConfirmationOfferId()
+    {
+        return $this->confirmationOfferId;
     }
 }


### PR DESCRIPTION
So we can find needed mobile confirmation by offer_id from Confirmations object instead of use getConfirmationTradeOfferId for each confirmation.